### PR TITLE
Update ShareX configuration example

### DIFF
--- a/sharex-config.sxcu.example
+++ b/sharex-config.sxcu.example
@@ -1,15 +1,15 @@
 {
-  "Version": "13.4.0",
-  "Name": "CloudFront AI Image Uploader",
-  "DestinationType": "ImageUploader",
+  "Version": "18.0.1",
+  "DestinationType": "ImageUploader, FileUploader",
   "RequestMethod": "POST",
   "RequestURL": "http://localhost:3456/upload",
+  "Headers": {
+    "x-upload-secret": "YOUR_UPLOAD_SECRET_HERE"
+  },
   "Body": "MultipartFormData",
   "Arguments": {
     "secret": "YOUR_UPLOAD_SECRET_HERE"
   },
   "FileFormName": "file",
-  "URL": "$json:url$",
-  "DeletionURL": "",
-  "ErrorMessage": "$json:error$"
+  "URL": "{json:url}"
 }


### PR DESCRIPTION
## Summary
- Update to ShareX version 18.0.1
- Add FileUploader support alongside ImageUploader  
- Add Headers section with x-upload-secret
- Update URL format to use {json:url} syntax
- Maintain backward compatibility with Arguments section

## Test plan
- [ ] Verify ShareX can import the configuration file
- [ ] Test upload functionality with the updated configuration
- [ ] Confirm both ImageUploader and FileUploader work correctly